### PR TITLE
Sp/child work

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ParentComponent } from './parent/containers/parent.component';
 import { TasksPageComponent } from './tasks/tasks-page/tasks-page.component';
+import { ChildComponent } from './child/child.component';
 
 const routes: Routes = [
   { path: 'family/:id', component: ParentComponent },
@@ -12,7 +13,8 @@ const routes: Routes = [
   { path: 'login', component: LoginComponent},
   { path: '', redirectTo: '/login', pathMatch: 'full'},
   { path: 'family/:id/members', component: MembersComponent },
-  { path: 'family/:id/tasks', component: TasksPageComponent }
+  { path: 'family/:id/tasks', component: TasksPageComponent },
+  { path: 'child/:id', component: ChildComponent }
 ];
 
 @NgModule({

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { TaskNotificationComponent } from './tasks/task-notification/task-notifi
 import { TasksDisplayComponent } from './tasks/tasks-display/tasks-display.component';
 
 import { MembersComponent } from './members/containers/members.component';
+import { SharedModule } from './shared/shared.module';
 
 @NgModule({
   declarations: [
@@ -45,7 +46,8 @@ import { MembersComponent } from './members/containers/members.component';
     AppRoutingModule,
     ReactiveFormsModule,
     FormsModule,
-    NgbModule.forRoot()
+    NgbModule.forRoot(),
+    SharedModule
   ],
   entryComponents: [
     GroundingAppealComponent

--- a/frontend/src/app/child/child.component.css
+++ b/frontend/src/app/child/child.component.css
@@ -1,19 +1,19 @@
-.row {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+#jumbotron-container {
+  margin: auto;
 }
 
-.jumbotron {
-  color: #f6f7f8;
-  background: rgb(37,112,233);
-  background: linear-gradient(34deg, rgba(37,112,233,1) 9%, rgba(36,182,255,1) 94%);
+#jumbo-title {
+  font-size: 50px;
 }
 
-fa-icon {
-  color: gold;
+.info {
+  width: 25em;
 }
 
-.jumbotron {
-  box-shadow: 0px 3px 15px rgba(0,0,0,0.2);
+.info .line {
+  box-sizing: border-box;
+  margin: 0.5em auto 1em auto;
+  width: 50%;
+  border-top: 1px solid #f6f7f8;
 }
 

--- a/frontend/src/app/child/child.component.html
+++ b/frontend/src/app/child/child.component.html
@@ -13,11 +13,7 @@
           <div id="child-rating">
             <h4 class="display-6">
               Rating
-              <fa-icon [icon]="faStar" size="lg"></fa-icon>
-            <fa-icon [icon]="faStar" size="lg"></fa-icon>
-            <fa-icon [icon]="faStar" size="lg"></fa-icon>
-            <fa-icon [icon]="faStar" size="lg"></fa-icon>
-            <fa-icon [icon]="faStarHalfAlt" size="lg"></fa-icon>
+              <app-rating [numStars]="3" [editable]="false"></app-rating>
             </h4>
           </div>
           <div id="child-status">

--- a/frontend/src/app/child/child.component.html
+++ b/frontend/src/app/child/child.component.html
@@ -1,29 +1,27 @@
 <div>
-  <div class="jumbotron jumbotron-fluid">
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-sm-6">
-          <h1 class="display-4">{{ child?.firstName }} {{ child?.lastName }}</h1>
-          <h5 class="display-8">Child</h5>
-          <p class="lead">
-            Parents: Josh Oh and Rebecca Oh
-          </p>
+  <div class="jumbotron" id="header">
+    <div class="container" id="jumbotron-container">
+      <div class="row justify-content-around align-items-center">
+        <div>
+          <h1 id="jumbo-title">{{ child?.firstName }} {{ child?.lastName }}</h1>
+          <i>Child</i>
         </div>
-        <div class="col-sm-6">
-          <div id="child-rating">
-            <h4 class="display-6">
-              Rating
-              <app-rating [numStars]="child?.rating" [editable]="false"></app-rating>
-            </h4>
+        <div class="info d-flex flex-column">
+          <h2 class="align-self-center mb-1">Information</h2>
+          <div class="line"></div>
+          <div class="row justify-content-around">
+            <span><strong>Rating</strong></span>
+            <span><strong>Status</strong></span>
           </div>
-          <div id="child-status">
-            <h4 class="display-6">
-              Status
-              <span *ngIf="!child?.isGrounded"class="badge badge-success">Not Grounded</span>
+          <div class="row justify-content-around">
+            <h4 id="child-rating"><app-rating [numStars]="child?.rating" [editable]="false"></app-rating></h4>
+            <h4 id="child-status">
+              <span *ngIf="!child?.isGrounded" class="badge badge-success">Not Grounded</span>
               <span *ngIf="child?.isGrounded" class="badge badge-danger">Grounded</span>
             </h4>
-            <button *ngIf="child?.isGrounded" class="btn btn-light" (click)="openGroundingAppealModal()">Appeal Grounding</button>
           </div>
+          <button *ngIf="child?.isGrounded" class="btn btn-light" (click)="openGroundingAppealModal()">Appeal
+              Grounding</button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/child/child.component.html
+++ b/frontend/src/app/child/child.component.html
@@ -3,7 +3,7 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-sm-6">
-          <h1 class="display-4">Amanda Oh</h1>
+          <h1 class="display-4">{{ child?.firstName }} {{ child?.lastName }}</h1>
           <h5 class="display-8">Child</h5>
           <p class="lead">
             Parents: Josh Oh and Rebecca Oh
@@ -13,21 +13,21 @@
           <div id="child-rating">
             <h4 class="display-6">
               Rating
-              <app-rating [numStars]="3" [editable]="false"></app-rating>
+              <app-rating [numStars]="child?.rating" [editable]="false"></app-rating>
             </h4>
           </div>
           <div id="child-status">
             <h4 class="display-6">
               Status
-              <span *ngIf="!isGrounded"class="badge badge-success">Not Grounded</span>
-              <span *ngIf="isGrounded" class="badge badge-danger">Grounded</span>
+              <span *ngIf="!child?.isGrounded"class="badge badge-success">Not Grounded</span>
+              <span *ngIf="child?.isGrounded" class="badge badge-danger">Grounded</span>
             </h4>
-            <button *ngIf="isGrounded" class="btn btn-light" (click)="openGroundingAppealModal()">Appeal Grounding</button>
+            <button *ngIf="child?.isGrounded" class="btn btn-light" (click)="openGroundingAppealModal()">Appeal Grounding</button>
           </div>
         </div>
       </div>
     </div>
   </div>
 
-    <app-tasks-display [tasks]="tasks"></app-tasks-display>
+  <app-tasks-display [tasks]="child?.tasks"></app-tasks-display>
 </div>

--- a/frontend/src/app/child/child.component.ts
+++ b/frontend/src/app/child/child.component.ts
@@ -2,8 +2,10 @@ import { Component, OnInit } from '@angular/core';
 import { faStar, faStarHalfAlt } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { GroundingAppealComponent } from '../grounding-appeal/grounding-appeal.component';
-import { Task } from '../../domain/models';
+import { Task, Child } from '../../domain/models';
 import { TasksService } from 'src/services/tasks/tasks.service';
+import { MembersService } from '../members/members.service';
+import { ChildrenService } from 'src/services/children/children.service';
 
 @Component({
   selector: 'app-child',
@@ -14,15 +16,30 @@ export class ChildComponent implements OnInit {
   faStar = faStar;
   faStarHalfAlt = faStarHalfAlt;
 
-  userID = 1;
+  userID = 5;
+  child: Child;
   isGrounded = true;
   tasks: Task[];
 
-  constructor(private modalService: NgbModal, private TasksService: TasksService) { }
+  constructor(private modalService: NgbModal,
+              private tasksService: TasksService,
+              private memberService: MembersService,
+              private childrenService: ChildrenService) { }
 
   ngOnInit() {
-    this.TasksService.getUserTasks(this.userID).subscribe(results => {
-      this.tasks = results;
+    this.loadChild();
+  }
+
+  loadChild() {
+    this.memberService.getMember(this.userID).subscribe(childInfo => {
+      this.child = childInfo;
+      this.childrenService.getChildDetails(this.userID).subscribe(childDetails => {
+        this.child.rating = +childDetails.rating;
+        this.child.isGrounded = !!+childDetails.groundedStatus;
+        this.tasksService.getUserTasks(this.userID).subscribe(childTasks => {
+          this.child.tasks = childTasks;
+        });
+      });
     });
   }
 

--- a/frontend/src/app/child/child.component.ts
+++ b/frontend/src/app/child/child.component.ts
@@ -6,6 +6,7 @@ import { Task, Child } from '../../domain/models';
 import { TasksService } from 'src/services/tasks/tasks.service';
 import { MembersService } from '../members/members.service';
 import { ChildrenService } from 'src/services/children/children.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-child',
@@ -16,7 +17,7 @@ export class ChildComponent implements OnInit {
   faStar = faStar;
   faStarHalfAlt = faStarHalfAlt;
 
-  userID = 5;
+  userID: number;
   child: Child;
   isGrounded = true;
   tasks: Task[];
@@ -24,9 +25,11 @@ export class ChildComponent implements OnInit {
   constructor(private modalService: NgbModal,
               private tasksService: TasksService,
               private memberService: MembersService,
-              private childrenService: ChildrenService) { }
+              private childrenService: ChildrenService,
+              private activatedRoute: ActivatedRoute) { }
 
   ngOnInit() {
+    this.userID = this.activatedRoute.snapshot.params['id'];
     this.loadChild();
   }
 

--- a/frontend/src/app/members/members.service.ts
+++ b/frontend/src/app/members/members.service.ts
@@ -32,6 +32,12 @@ export class MembersService {
       .pipe(catchError(this.handleException));
   }
 
+  getMember(memberId: number): Observable<Member> {
+    return this.httpClient.get<Member>(`${this.baseUrl}/users/${memberId}`, this.httpOptions).pipe(
+      catchError(this.handleException)
+    );
+  }
+
   toggleGround(isGrounded: boolean, childId: number): Observable<Child> {
     const groundType: string = isGrounded ? 'unground' : 'ground';
     return this.httpClient

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-sm navbar-light bg-light">
-  <a class="navbar-brand" [routerLink]="['family']">Fam.ly</a>
+  <a class="navbar-brand" [routerLink]="['/family/3']">Fam.ly</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/frontend/src/app/parent/containers/parent.component.css
+++ b/frontend/src/app/parent/containers/parent.component.css
@@ -2,7 +2,7 @@
   width: 8em;
 }
 
-#view-tasks-btn {
+#view-tasks-btn, #view-members-btn {
   margin: 1em 0 0 0;
   width: 11em;
 }
@@ -47,11 +47,11 @@
   transform: scale(1.3);
 }
 
-#view-tasks-btn:hover span {
+#view-tasks-btn:hover span, #view-members-btn:hover span {
   padding-right: 1.2em;
 }
 
-#view-tasks-btn:hover span:after {
+#view-tasks-btn:hover span:after, #view-members-btn:hover span:after {
   opacity: 1;
   right: 0em;
 }
@@ -119,4 +119,8 @@
 #newTaskHeader {
   background: rgb(37,112,233);
   background: linear-gradient(34deg, rgba(37,112,233,1) 9%, rgba(36,182,255,1) 94%);
+}
+
+hr {
+  border-color: white;
 }

--- a/frontend/src/app/parent/containers/parent.component.html
+++ b/frontend/src/app/parent/containers/parent.component.html
@@ -32,11 +32,15 @@
           <h1>Members</h1>
           <button class="fast-animated scale plus btn btn-success add-btn" (click)="openMemberModal()"><span>Add Fam</span></button>
         </div>
-        <table class="table table-striped rounded">
+        <table *ngIf="members?.length > 0" class="table table-striped rounded">
           <tbody>
             <tr *ngFor="let member of members">
-              <td>{{ member.name }}</td>
-              <td>{{ member.type }}</td>
+              <td>{{ member.firstName }} {{ member.lastName }}</td>
+              <td *ngIf="member.isParent">Parent</td>
+              <td *ngIf="!member.isParent">Child</td>
+              <td *ngIf="!member.isParent">
+                <button class="btn btn-sm btn-primary" [routerLink]="['/child', member.userID]">Go To Child Page</button>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/app/parent/containers/parent.component.html
+++ b/frontend/src/app/parent/containers/parent.component.html
@@ -2,9 +2,16 @@
   <div class="jumbotron" id="header">
     <div class="container" id="jumbotron-container">
       <div class="row justify-content-around align-items-center">
-        <div>
-          <h1 id="jumbo-title">Doe Family</h1>
-          <i>Fam since October 2018</i>
+        <div id="family-info">
+          <h1 id="jumbo-title">Family Page</h1>
+          <i>Fam since {{ familyInfo?.registrationDate | date }}</i>
+          <br>
+          <hr>
+          <span><b>Address</b>: {{ familyInfo?.address }}</span>
+          <br>
+          <span><b>Email</b>: {{ familyInfo?.email }}</span>
+          <br>
+          <span><b>Phone</b>: {{ familyInfo?.phone }}</span>
         </div>
         <div class="stats d-flex flex-column">
           <h2 class="align-self-center mb-1">Stats</h2>
@@ -27,7 +34,7 @@
   </div>
   <div class="container">
     <div class="row justify-content-around">
-      <div class="col-md-6 col-lg-5 col-xl-4" id="members-container">
+      <div class="col-md-6 col-lg-5 col-xl-4 d-flex flex-column" id="members-container">
         <div class="table-section row justify-content-between align-items-center">
           <h1>Members</h1>
           <button class="fast-animated scale plus btn btn-success add-btn" (click)="openMemberModal()"><span>Add Fam</span></button>
@@ -39,11 +46,14 @@
               <td *ngIf="member.isParent">Parent</td>
               <td *ngIf="!member.isParent">Child</td>
               <td *ngIf="!member.isParent">
-                <button class="btn btn-sm btn-primary" [routerLink]="['/child', member.userID]">Go To Child Page</button>
+                <button class="btn btn-sm btn-warning" [routerLink]="['/child', member.userID]">Go To Child Page</button>
               </td>
             </tr>
           </tbody>
         </table>
+        <button class="fast-animated push arrow btn btn-primary align-self-center" id="view-members-btn">
+          <span>View All Members</span>
+        </button>
       </div>
       <div class="col-md-12 col-lg-7 d-flex flex-column" id="tasks-container">
         <div class="table-section row justify-content-between align-items-center">
@@ -56,17 +66,21 @@
             <tr *ngFor="let task of tasks" [ngSwitch]="task.status.toLowerCase()">
               <td>{{ task.taskTitle }}</td>
               <td>{{ task.assigneeID }}</td>
-              <td *ngSwitchCase="'incomplete'" align="center"><span class="badge badge-primary">{{ task.status.toLowerCase() }}</span></td>
-              <td *ngSwitchCase="'complete'" align="center"><span class="badge badge-success">{{ task.status.toLowerCase() }}</span></td>
-              <td *ngSwitchCase="'pending'" align="center"><span class="badge badge-warning">{{ task.status.toLowerCase() }}</span></td>
-              <td *ngSwitchCase="'rejected'" align="center"><span class="badge badge-dark">{{ task.status.toLowerCase() }}</span></td>
+              <td *ngSwitchCase="'incomplete'" align="center"><span class="badge badge-primary">{{
+                  task.status.toLowerCase() }}</span></td>
+              <td *ngSwitchCase="'complete'" align="center"><span class="badge badge-success">{{
+                  task.status.toLowerCase() }}</span></td>
+              <td *ngSwitchCase="'pending'" align="center"><span class="badge badge-warning">{{
+                  task.status.toLowerCase() }}</span></td>
+              <td *ngSwitchCase="'rejected'" align="center"><span class="badge badge-dark">{{ task.status.toLowerCase()
+                  }}</span></td>
               <td *ngSwitchDefault></td>
             </tr>
           </tbody>
         </table>
-          <button class="fast-animated push arrow btn btn-primary align-self-center" id="view-tasks-btn" [routerLink]="['tasks']">
-            <span>View All Tasks</span>
-          </button>
+        <button class="fast-animated push arrow btn btn-primary align-self-center" id="view-tasks-btn" [routerLink]="['tasks']">
+          <span>View All Tasks</span>
+        </button>
 
       </div>
     </div>

--- a/frontend/src/app/parent/containers/parent.component.ts
+++ b/frontend/src/app/parent/containers/parent.component.ts
@@ -26,24 +26,24 @@ export class ParentComponent implements OnInit {
 
   tasks: Task[];
   members: Member[];
+  familyInfo: any;
 
   numCompletedTasks: number = 0;
 
   constructor(private modalService: NgbModal,
               private tasksService: TasksService,
-              private parentsService: ParentsService,
-              private childrenService: ChildrenService,
-              private router: Router) { }
+              private parentsService: ParentsService) { }
 
   ngOnInit() {
-    // this.members = [
-    //   { id: 1, name: 'John', type: 'Parent' },
-    //   { id: 2, name: 'Jane', type: 'Parent' },
-    //   { id: 3, name: 'Jimbo', type: 'Child' },
-    //   { id: 4, name: 'Janette', type: 'Child' }
-    // ];
+    this.getFamilyInfo();
     this.getFamilyMembers();
     this.getFamilyTasks();
+  }
+
+  getFamilyInfo() {
+    this.parentsService.getFamilyInfo(this.familyID).subscribe(result => {
+      this.familyInfo = result;
+    })
   }
 
   getFamilyMembers() {

--- a/frontend/src/app/parent/containers/parent.component.ts
+++ b/frontend/src/app/parent/containers/parent.component.ts
@@ -8,6 +8,7 @@ import { Task, Member } from 'src/domain/models';
 import { ParentsService } from '../parents.service';
 import { ChildrenService } from 'src/services/children/children.service';
 import { Router } from '@angular/router';
+import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-parent',
@@ -24,7 +25,7 @@ export class ParentComponent implements OnInit {
   parentID = 3;
 
   tasks: Task[];
-  members: any[];
+  members: Member[];
 
   numCompletedTasks: number = 0;
 
@@ -35,14 +36,22 @@ export class ParentComponent implements OnInit {
               private router: Router) { }
 
   ngOnInit() {
-    this.members = [
-      { id: 1, name: 'John', type: 'Parent' },
-      { id: 2, name: 'Jane', type: 'Parent' },
-      { id: 3, name: 'Jimbo', type: 'Child' },
-      { id: 4, name: 'Janette', type: 'Child' }
-    ];
-
+    // this.members = [
+    //   { id: 1, name: 'John', type: 'Parent' },
+    //   { id: 2, name: 'Jane', type: 'Parent' },
+    //   { id: 3, name: 'Jimbo', type: 'Child' },
+    //   { id: 4, name: 'Janette', type: 'Child' }
+    // ];
+    this.getFamilyMembers();
     this.getFamilyTasks();
+  }
+
+  getFamilyMembers() {
+    forkJoin([this.parentsService.getParents(this.familyID), this.parentsService.getChildren(this.familyID)]).subscribe(results => {
+      let parents = results[0];
+      let children = results[1];
+      this.members = parents.concat(children);
+    });
   }
 
   getFamilyTasks() {

--- a/frontend/src/app/parent/parents.service.ts
+++ b/frontend/src/app/parent/parents.service.ts
@@ -1,8 +1,9 @@
-import { catchError } from 'rxjs/operators';
+import { catchError, concatAll } from 'rxjs/operators';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Member } from './../../domain/models/member';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
+import { Child } from 'src/domain/models';
 
 @Injectable()
 export class ParentsService {
@@ -20,6 +21,11 @@ export class ParentsService {
 
   getParents(familyId: number): Observable<Member[]> {
     return this.httpClient.get<Member[]>(`${this.baseUrl}/getParents/${familyId}`, this.httpOptions)
+      .pipe(catchError(this.handleException));
+  }
+
+  getChildren(familyId: number): Observable<Child[]> {
+    return this.httpClient.get<Child[]>(`${this.baseUrl}/getChildren/${familyId}`, this.httpOptions)
       .pipe(catchError(this.handleException));
   }
 

--- a/frontend/src/app/parent/parents.service.ts
+++ b/frontend/src/app/parent/parents.service.ts
@@ -19,6 +19,11 @@ export class ParentsService {
     })
   };
 
+  getFamilyInfo(familyId: number): Observable<any> {
+    return this.httpClient.get<Member[]>(`${this.baseUrl}/getfamilyInfo/${familyId}`, this.httpOptions)
+      .pipe(catchError(this.handleException));
+  }
+
   getParents(familyId: number): Observable<Member[]> {
     return this.httpClient.get<Member[]>(`${this.baseUrl}/getParents/${familyId}`, this.httpOptions)
       .pipe(catchError(this.handleException));

--- a/frontend/src/app/tasks/new-task-form/new-task-form.component.ts
+++ b/frontend/src/app/tasks/new-task-form/new-task-form.component.ts
@@ -65,9 +65,7 @@ export class NewTaskFormComponent implements OnInit {
     this.task.taskDescript = this.taskForm.value.description;
     this.task.taskAward = this.taskForm.value.award;
     this.task.deadline = this.taskForm.value.deadline;
-    console.log(this.taskForm.errors);
-    //this.activeModal.close(this.task);
-    this.activeModal.close();
+    this.activeModal.close(this.task);
     this.resetForm();
   }
 

--- a/frontend/src/app/tasks/tasks-display/tasks-display.component.ts
+++ b/frontend/src/app/tasks/tasks-display/tasks-display.component.ts
@@ -21,7 +21,6 @@ export class TasksDisplayComponent implements OnInit {
   ngOnInit() {
     this.filterBy = 'all';
     this.filterTasks();
-    console.log(this.tasks);
   }
 
   filterTasks() {

--- a/frontend/src/domain/models/child.ts
+++ b/frontend/src/domain/models/child.ts
@@ -3,8 +3,8 @@ import { Member } from './member';
 import { Task } from './task';
 
 export class Child extends Member {
-  rating: number;
-  isGrounded: boolean;
-  infractions: Infraction[] | Number;
-  tasks: Task[] | Number;
+  rating?: number;
+  isGrounded?: boolean;
+  infractions?: Infraction[] | Number;
+  tasks?: Task[] | Number;
 }

--- a/frontend/src/services/children/children.service.ts
+++ b/frontend/src/services/children/children.service.ts
@@ -43,6 +43,18 @@ export class ChildrenService {
     );
   }
 
+  getChildDetails(childId: number): Observable<any> {
+    return this.httpClient.get<any>(`${this.baseUrl}/childDetails/${childId}`, this.httpOptions).pipe(
+      catchError(this.handleException)
+    );
+  }
+
+  getChildAvgRating(childId: number): Observable<number> {
+    return this.httpClient.get<number>(`${this.baseUrl}/children/${childId}/avg-rating`, this.httpOptions).pipe(
+      catchError(this.handleException)
+    );
+  }
+
   protected handleException(exception: any) {
     const message = `${exception.status} : ${exception.statusText}\r\n${exception.message}`;
     return Observable.throw(exception);


### PR DESCRIPTION
Parent component now gets all family members from backend and displays them on the page. For each child in the table of members, there is a button to go to that child's specific page with their own tasks and everything is dynamically updated there. Fixed styling on child jumbotron and the rating/grounded status is pulled from the backend as well.

We do need a separate members component page with a button where we can go to members and edit them, I've added the button but it doesn't go anywhere right now. Whoever's in charge of that can hook it up.

Parent component also now pulls family info dynamically as well, woohoo! Some of the info won't be consistent/make sense if you change the familyID because of our mock data and the associations between different parents/children/tasks.

Questions: difference between familyID and parentID? NOTE: ALL IDS ARE HARDCODED RIGHT NOW because I didn't know how to hook it up from login/auth stuff.